### PR TITLE
Changes to support Node Local extents.

### DIFF
--- a/client/src/margo_client.h
+++ b/client/src/margo_client.h
@@ -37,6 +37,7 @@ typedef struct ClientRpcIds {
     hg_id_t laminate_id;
     hg_id_t fsync_id;
     hg_id_t mread_id;
+    hg_id_t node_local_extents_get_id;
 
     /* server-to-client */
     hg_id_t heartbeat_id;
@@ -102,5 +103,10 @@ int invoke_client_truncate_rpc(unifyfs_client* client,
 int invoke_client_unlink_rpc(unifyfs_client* client,
                              int gfid);
 
+int invoke_client_node_local_extents_get_rpc(unifyfs_client* client,
+                                             int num_req,
+                                             extents_list_t* read_req,
+                                             int* extent_count,
+                                             extents_list_t* extents);
 
 #endif // MARGO_CLIENT_H

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -345,7 +345,7 @@ static int init_superblock_shm(unifyfs_client* client,
 
                 /* Reset our segment tree to track extents for all writes
                  * by this process, can be used to read back local data */
-                if (client->use_local_extents) {
+                if (client->use_local_extents || client->use_node_local_extents) {
                     seg_tree_init(&meta->extents);
                 }
             }

--- a/client/src/unifyfs_api.c
+++ b/client/src/unifyfs_api.c
@@ -111,7 +111,16 @@ unifyfs_rc unifyfs_initialize(const char* mountpoint,
             client->max_files = (int)l;
         }
     }
-
+    /* Determine if we should track all node local extents and use them
+     * to service read requests if all data is node local */
+    client->use_node_local_extents = 0;
+    cfgval = client_cfg->client_node_local_extents;
+    if (cfgval != NULL) {
+        rc = configurator_bool_val(cfgval, &b);
+        if (rc == 0) {
+            client->use_node_local_extents = (bool)b;
+        }
+    }
     /* Determine if we should track all write extents and use them
      * to service read requests if all data is local */
     client->use_local_extents = 0;

--- a/client/src/unifyfs_api_internal.h
+++ b/client/src/unifyfs_api_internal.h
@@ -37,6 +37,7 @@ typedef struct {
     int pending_unlink;           /* received unlink callback */
 
     int needs_sync;               /* have unsynced writes */
+    int needs_extents_sync;       /* have unsynced read extents from node-local server */
     struct seg_tree extents_sync; /* Segment tree containing our coalesced
                                    * writes between sync operations */
 
@@ -65,6 +66,7 @@ typedef struct unifyfs_client {
 
     bool use_fsync_persist;          /* persist data to storage on fsync() */
     bool use_local_extents;          /* enable tracking of local extents */
+    bool use_node_local_extents;     /* enable tracking of extents within node only for laminate files */
     bool use_write_sync;             /* sync for every write operation */
     bool use_unifyfs_magic;          /* return UNIFYFS (true) or TMPFS (false)
                                       * magic value from statfs() */

--- a/client/src/unifyfs_fid.c
+++ b/client/src/unifyfs_fid.c
@@ -64,7 +64,7 @@ static int fid_storage_alloc(unifyfs_client* client,
 
         /* Initialize our segment tree to track extents for all writes
          * by this process, can be used to read back local data */
-        if (client->use_local_extents) {
+        if (client->use_local_extents || client->use_node_local_extents) {
             rc = seg_tree_init(&meta->extents);
             if (rc != 0) {
                 /* clean up extents_sync tree we initialized */
@@ -114,7 +114,7 @@ static int fid_storage_free(unifyfs_client* client,
             seg_tree_destroy(&meta->extents_sync);
 
             /* Free our extent seg_tree */
-            if (client->use_local_extents) {
+            if (client->use_local_extents || client->use_node_local_extents) {
                 seg_tree_destroy(&meta->extents);
             }
         }
@@ -250,6 +250,8 @@ int unifyfs_fid_create_file(unifyfs_client* client,
     meta->fid            = fid;
     meta->storage        = FILE_STORAGE_NULL;
     meta->needs_sync     = 0;
+    /* first time we read a laminated file we want to sync extents */
+    meta->needs_extents_sync     = 1;
     meta->pending_unlink = 0;
 
     return fid;

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -72,6 +72,7 @@
     UNIFYFS_CFG(client, cwd, STRING, NULLSTRING, "current working directory", NULL) \
     UNIFYFS_CFG(client, fsync_persist, BOOL, on, "persist written data to storage on fsync()", NULL) \
     UNIFYFS_CFG(client, local_extents, BOOL, off, "use client-cached extents to service local reads without consulting local server", NULL) \
+    UNIFYFS_CFG(client, node_local_extents, BOOL, off, "use node-local extents to service local reads without consulting local server everytime", NULL) \
     UNIFYFS_CFG(client, max_files, INT, UNIFYFS_CLIENT_MAX_FILES, "client max file count", NULL) \
     UNIFYFS_CFG(client, write_index_size, INT, UNIFYFS_CLIENT_WRITE_INDEX_SIZE, "write metadata index buffer size", NULL) \
     UNIFYFS_CFG(client, write_sync, BOOL, off, "sync every write to server", NULL) \

--- a/server/src/margo_server.c
+++ b/server/src/margo_server.c
@@ -235,6 +235,11 @@ static void register_server_server_rpcs(margo_instance_id mid)
         MARGO_REGISTER(mid, "unlink_bcast_rpc",
                        unlink_bcast_in_t, unlink_bcast_out_t,
                        unlink_bcast_rpc);
+
+    unifyfsd_rpc_context->rpcs.node_local_extents_get_id =
+       MARGO_REGISTER(mid, "unifyfs_node_local_extents_get_rpc",
+                      unifyfs_node_local_extents_get_in_t, unifyfs_node_local_extents_get_out_t,
+                      unifyfs_node_local_extents_get_rpc);
 }
 
 /* setup_local_target - Initializes the client-server margo target */
@@ -318,6 +323,10 @@ static void register_client_server_rpcs(margo_instance_id mid)
     MARGO_REGISTER(mid, "unifyfs_mread_rpc",
                    unifyfs_mread_in_t, unifyfs_mread_out_t,
                    unifyfs_mread_rpc);
+
+    MARGO_REGISTER(mid, "unifyfs_node_local_extents_get_rpc",
+                   unifyfs_node_local_extents_get_in_t, unifyfs_node_local_extents_get_out_t,
+                   unifyfs_node_local_extents_get_rpc);
 
     /* register the RPCs we call (and capture assigned hg_id_t) */
     unifyfsd_rpc_context->rpcs.client_heartbeat_id =

--- a/server/src/margo_server.h
+++ b/server/src/margo_server.h
@@ -49,6 +49,7 @@ typedef struct ServerRpcIds {
     hg_id_t truncate_id;
     hg_id_t truncate_bcast_id;
     hg_id_t unlink_bcast_id;
+    hg_id_t node_local_extents_get_id;
 
     /* client-server rpcs */
     hg_id_t client_heartbeat_id;

--- a/server/src/unifyfs_client_rpc.c
+++ b/server/src/unifyfs_client_rpc.c
@@ -863,3 +863,65 @@ static void unifyfs_mread_rpc(hg_handle_t handle)
     }
 }
 DEFINE_MARGO_RPC_HANDLER(unifyfs_mread_rpc)
+
+/* returns file extents from node local server
+ * given a global file id */
+static void unifyfs_node_local_extents_get_rpc(hg_handle_t handle)
+{
+    int ret = UNIFYFS_SUCCESS;
+    hg_return_t hret;
+
+    /* get input params */
+    unifyfs_node_local_extents_get_in_t* in = malloc(sizeof(*in));
+    if (NULL == in) {
+        ret = ENOMEM;
+    } else {
+        hret = margo_get_input(handle, in);
+        if (hret != HG_SUCCESS) {
+            LOGERR("margo_get_input() failed");
+            ret = UNIFYFS_ERROR_MARGO;
+        } else {
+            client_rpc_req_t* req = malloc(sizeof(client_rpc_req_t));
+            if (NULL == req) {
+                ret = ENOMEM;
+            } else {
+                unifyfs_fops_ctx_t ctx = {
+                        .app_id = in->app_id,
+                        .client_id = in->client_id,
+                };
+                req->req_type = UNIFYFS_CLIENT_RPC_NODE_LOCAL_EXTENTS_GET;
+                req->handle = handle;
+                req->input = (void*) in;
+                req->bulk_buf = NULL;
+                req->bulk_sz = 0;
+                ret = rm_submit_client_rpc_request(&ctx, req);
+            }
+
+            if (ret != UNIFYFS_SUCCESS) {
+                if (NULL != req) {
+                    free(req);
+                }
+                margo_free_input(handle, in);
+            }
+        }
+    }
+
+    /* if we hit an error during request submission, respond with the error */
+    if (ret != UNIFYFS_SUCCESS) {
+        if (NULL != in) {
+            free(in);
+        }
+        /* return to caller */
+        unifyfs_node_local_extents_get_out_t out;
+        out.ret = (int32_t) ret;
+        out.extent_count = 0;
+        hret = margo_respond(handle, &out);
+        if (hret != HG_SUCCESS) {
+            LOGERR("margo_respond() failed");
+        }
+
+        /* free margo resources */
+        margo_destroy(handle);
+    }
+}
+DEFINE_MARGO_RPC_HANDLER(unifyfs_node_local_extents_get_rpc)

--- a/t/api/init-fini.c
+++ b/t/api/init-fini.c
@@ -19,11 +19,14 @@ int api_initialize_test(char* unifyfs_root,
 {
     diag("Starting API initialization test");
 
-    int n_configs = 1;
-    unifyfs_cfg_option chk_size = { .opt_name = "logio.chunk_size",
-                                    .opt_value = "32768" };
+    int n_configs = 2;
+    unifyfs_cfg_option options[2];
+    options[0].opt_name = "logio.chunk_size";
+    options[0].opt_value = "32768";
+    options[1].opt_name = "client.node_local_extents";
+    options[1].opt_value = "on";
 
-    int rc = unifyfs_initialize(unifyfs_root, &chk_size, n_configs, fshdl);
+    int rc = unifyfs_initialize(unifyfs_root, options, n_configs, fshdl);
     ok(rc == UNIFYFS_SUCCESS,
        "%s:%d unifyfs_initialize() is successful: rc=%d (%s)",
        __FILE__, __LINE__, rc, unifyfs_rc_enum_description(rc));


### PR DESCRIPTION
- The client has a new configuration for node_local_extents
- On first read of a laminated file if client.node_local_extents is enabled we fetch extents from server and update the local extents
- This allows reads to be executed locally
- on server we get our extents using unifyfs_invoke_find_extents_rpc

In these cases we do only one rpc per request group and fetch extents for all files which are laminated.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
